### PR TITLE
rename UnitRegistry from unit -> ureg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Solution`: support new units in `get_amount` - ppm, ppb, eq/L, etc.
 - `Solution`: implemented arithmetic operations `+` (for mixing two solutions), `*` and `\` for scaling their amounts
 
+### Changed
+
+- `pyEQL.unit` was renamed to `pyEQL.ureg` (short for `UnitRegistry`) for consistency with the `pint` documentation and tutorials.
+
 ## [v0.6.0] - 2023-08-15
 
 ### Added

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -74,8 +74,8 @@ pyEQL uses [pint](https://github.com/hgrecco/pint) to perform units-aware calcul
 Quantity objects that contain both a magnitude and a unit.
 
 > ```pycon
-> >>> from pyEQL import unit
-> >>> test_qty = pyEQL.unit('1 kg/m**3')
+> >>> from pyEQL import ureg
+> >>> test_qty = pyEQL.ureg('1 kg/m**3')
 > 1.0 kilogram/meter3
 > ```
 
@@ -111,13 +111,16 @@ To access pyEQL's main features in your project all that is needed is an import 
 > >>> import pyEQL
 > ```
 
-In order to directly create `Quantity`  objects, you need to explicitly import the `unit` module:
+In order to directly create `Quantity`  objects, you need to explicitly import `UnitRegistry`, which you can do as follows:
 
 > ```pycon
-> >>> from pyEQL import unit
-> >>> test_qty = unit('1 kg/m**3')
+> >>> from pyEQL import ureg
+> >>> test_qty = ureg('1 kg/m**3')
 > 1.0 kilogram/meter3
 > ```
+:::{note}
+Note that the meaning of `ureg` is equivalent in the above `pyEQL` examples and in the [pint documentation](http://pint.readthedocs.io/). `pyEQL` instantiates its own `UnitRegistry` (with custom definitions for solution chemistry) and assigns it to the variable `ureg`. In most `pint` examples, the line `ureq = UnitRegistry()` does the same thing.
+:::
 
 :::{warning}
 if you use `pyEQL` in conjunction with another module that also uses pint for units-aware calculations, you must convert all `Quantity`  objects to strings before passing them to the other module, as pint cannot perform mathematical operations on units that belong to different "registries."  See the [pint documentation](http://pint.readthedocs.io/) for more details.

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,7 @@ full =
 
 [tool:pytest]
 # Specify command line options as you would do when invoking pytest directly.
-# e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
+# e.g. --cov-report html (or xml) for html/xml output or --junitxml jureg.xml
 # in order to write a coverage file that can be read by Jenkins.
 # CAUTION: --cov flags may prohibit setting breakpoints while debugging.
 #          Comment those flags to avoid this py.test issue.

--- a/src/pyEQL/__init__.py
+++ b/src/pyEQL/__init__.py
@@ -8,7 +8,6 @@ and performing chemical thermodynamics computations.
 :copyright: 2013-2023 by Ryan S. Kingsbury
 :license: LGPL, see LICENSE for more details.
 """
-import sys
 from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 
 from pint import UnitRegistry
@@ -28,17 +27,17 @@ finally:
 # Registry are only instantiated once.
 # here we assign the identifier 'unit' to the UnitRegistry
 # the cache_folder arg is added to speed up registry instantiation
-unit = UnitRegistry(cache_folder=":auto:")
+ureg = UnitRegistry(cache_folder=":auto:")
 # convert "offset units" so that, e.g. Quantity('25 degC') works without error
 # see https://pint.readthedocs.io/en/0.22/user/nonmult.html?highlight=offset#temperature-conversion
-unit.autoconvert_offset_to_baseunit = True
+ureg.autoconvert_offset_to_baseunit = True
 # append custom unit definitions and contexts
 fname = resource_filename("pyEQL", "pint_custom_units.txt")
-unit.load_definitions(fname)
+ureg.load_definitions(fname)
 # activate the "chemistry" context globally
-unit.enable_contexts("chem")
+ureg.enable_contexts("chem")
 # set the default string formatting for pint quantities
-unit.default_format = "P~"
+ureg.default_format = "P~"
 
 from pyEQL.functions import *  # noqa: E402, F403
 from pyEQL.solution import Solution  # noqa: E402

--- a/src/pyEQL/activity_correction.py
+++ b/src/pyEQL/activity_correction.py
@@ -17,7 +17,7 @@ import math
 from iapws import IAPWS95
 
 # the pint unit registry
-from pyEQL import unit
+from pyEQL import ureg
 from pyEQL.logging_system import logger
 
 
@@ -47,22 +47,22 @@ def _debye_parameter_B(temperature="25 degC"):
 
     """
     water_substance = IAPWS95(
-        T=unit.Quantity(temperature).magnitude,
-        P=unit.Quantity("1 atm").to("MPa").magnitude,
+        T=ureg.Quantity(temperature).magnitude,
+        P=ureg.Quantity("1 atm").to("MPa").magnitude,
     )
 
     param_B = (
         8
         * math.pi
-        * unit.N_A
-        * unit.elementary_charge**2
+        * ureg.N_A
+        * ureg.elementary_charge**2
         / (
             water_substance.mu
-            * unit.Quantity("1 g/L")  # in g/L
-            * unit.epsilon_0
+            * ureg.Quantity("1 g/L")  # in g/L
+            * ureg.epsilon_0
             * water_substance.epsilon
-            * unit.boltzmann_constant
-            * unit.Quantity(temperature)
+            * ureg.boltzmann_constant
+            * ureg.Quantity(temperature)
         )
     ) ** 0.5
     return param_B.to_base_units()
@@ -108,20 +108,20 @@ def _debye_parameter_activity(temperature="25 degC"):
 
     """
     water_substance = IAPWS95(
-        T=unit.Quantity(temperature).magnitude,
-        P=unit.Quantity("1 atm").to("MPa").magnitude,
+        T=ureg.Quantity(temperature).magnitude,
+        P=ureg.Quantity("1 atm").to("MPa").magnitude,
     )
 
     debyeparam = (
-        unit.elementary_charge**3
-        * (2 * math.pi * unit.N_A * water_substance.rho * unit.Quantity("1 g/L")) ** 0.5
+        ureg.elementary_charge**3
+        * (2 * math.pi * ureg.N_A * water_substance.rho * ureg.Quantity("1 g/L")) ** 0.5
         / (
             4
             * math.pi
-            * unit.epsilon_0
+            * ureg.epsilon_0
             * water_substance.epsilon
-            * unit.boltzmann_constant
-            * unit.Quantity(temperature)
+            * ureg.boltzmann_constant
+            * ureg.Quantity(temperature)
         )
         ** 1.5
     )
@@ -211,23 +211,23 @@ def _debye_parameter_volume(temperature="25 degC"):
 
     """
     water_substance = IAPWS95(
-        T=unit.Quantity(temperature).magnitude,
-        P=unit.Quantity("1 atm").to("MPa").magnitude,
+        T=ureg.Quantity(temperature).magnitude,
+        P=ureg.Quantity("1 atm").to("MPa").magnitude,
     )
 
     # TODO - add partial derivatives to calculation
     epsilon = water_substance.epsilon
-    dedp = unit.Quantity("-0.01275 1/MPa")
+    dedp = ureg.Quantity("-0.01275 1/MPa")
     result = (
         -2
         * _debye_parameter_osmotic(temperature)
-        * unit.R
-        * unit.Quantity(temperature)
-        * (3 / epsilon * dedp - 1 / unit.Quantity("2.2 GPa"))
+        * ureg.R
+        * ureg.Quantity(temperature)
+        * (3 / epsilon * dedp - 1 / ureg.Quantity("2.2 GPa"))
     )
-    # result = unit.Quantity('1.898 cm ** 3 * kg ** 0.5 /  mol ** 1.5')
+    # result = ureg.Quantity('1.898 cm ** 3 * kg ** 0.5 /  mol ** 1.5')
 
-    if unit.Quantity(temperature) != unit.Quantity("25 degC"):
+    if ureg.Quantity(temperature) != ureg.Quantity("25 degC"):
         logger.warning("Debye-Huckel limiting slope for volume is approximate when T is not equal to 25 degC")
 
     logger.info(f"Computed Debye-Huckel Limiting Slope for volume A^V = {result} at {temperature}")
@@ -277,7 +277,7 @@ def get_activity_coefficient_debyehuckel(ionic_strength, formal_charge=1, temper
 
     log_f = -_debye_parameter_activity(temperature) * formal_charge**2 * ionic_strength**0.5
 
-    return math.exp(log_f) * unit.Quantity("1 dimensionless")
+    return math.exp(log_f) * ureg.Quantity("1 dimensionless")
 
 
 def get_activity_coefficient_guntelberg(ionic_strength, formal_charge=1, temperature="25 degC"):
@@ -327,7 +327,7 @@ def get_activity_coefficient_guntelberg(ionic_strength, formal_charge=1, tempera
         / (1 + ionic_strength.magnitude**0.5)
     )
 
-    return math.exp(log_f) * unit.Quantity("1 dimensionless")
+    return math.exp(log_f) * ureg.Quantity("1 dimensionless")
 
 
 def get_activity_coefficient_davies(ionic_strength, formal_charge=1, temperature="25 degC"):
@@ -377,7 +377,7 @@ def get_activity_coefficient_davies(ionic_strength, formal_charge=1, temperature
         * (ionic_strength.magnitude**0.5 / (1 + ionic_strength.magnitude**0.5) - 0.2 * ionic_strength.magnitude)
     )
 
-    return math.exp(log_f) * unit.Quantity("1 dimensionless")
+    return math.exp(log_f) * ureg.Quantity("1 dimensionless")
 
 
 def get_activity_coefficient_pitzer(
@@ -430,10 +430,10 @@ def get_activity_coefficient_pitzer(
 
     Examples:
     --------
-    >>> get_activity_coefficient_pitzer(0.5*unit.Quantity('mol/kg'),0.5*unit.Quantity('mol/kg'),1,0.5,-.0181191983,-.4625822071,.4682,.000246063,1,-1,1,1,b=1.2)
+    >>> get_activity_coefficient_pitzer(0.5*ureg.Quantity('mol/kg'),0.5*ureg.Quantity('mol/kg'),1,0.5,-.0181191983,-.4625822071,.4682,.000246063,1,-1,1,1,b=1.2)
     ￼0.61915...
 
-    >>> get_activity_coefficient_pitzer(5.6153*unit.Quantity('mol/kg'),5.6153*unit.Quantity('mol/kg'),3,0.5,0.0369993,0.354664,0.0997513,-0.00171868,1,-1,1,1,b=1.2)
+    >>> get_activity_coefficient_pitzer(5.6153*ureg.Quantity('mol/kg'),5.6153*ureg.Quantity('mol/kg'),3,0.5,0.0369993,0.354664,0.0997513,-0.00171868,1,-1,1,1,b=1.2)
     ￼0.76331...
 
     NOTE: the examples below are for comparison with experimental and modeling data presented in
@@ -441,17 +441,17 @@ def get_activity_coefficient_pitzer(
 
     10 mol/kg ammonium nitrate. Estimated result (from graph) = 0.2725
 
-    >>> get_activity_coefficient_pitzer(10*unit.Quantity('mol/kg'),10*unit.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
+    >>> get_activity_coefficient_pitzer(10*ureg.Quantity('mol/kg'),10*ureg.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
     0.22595 ...
 
     5 mol/kg ammonium nitrate. Estimated result (from graph) = 0.3011
 
-    >>> get_activity_coefficient_pitzer(5*unit.Quantity('mol/kg'),5*unit.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
+    >>> get_activity_coefficient_pitzer(5*ureg.Quantity('mol/kg'),5*ureg.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
     0.30249 ...
 
     18 mol/kg ammonium nitrate. Estimated result (from graph) = 0.1653
 
-    >>> get_activity_coefficient_pitzer(18*unit.Quantity('mol/kg'),18*unit.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
+    >>> get_activity_coefficient_pitzer(18*ureg.Quantity('mol/kg'),18*ureg.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
     0.16241 ...
 
     References
@@ -482,14 +482,14 @@ def get_activity_coefficient_pitzer(
 
     """
     # assign proper units to alpha1, alpha2, and b
-    alpha1 = alpha1 * unit.Quantity("kg ** 0.5 / mol ** 0.5")
-    alpha2 = alpha2 * unit.Quantity("kg ** 0.5 / mol ** 0.5")
-    b = b * unit.Quantity("kg ** 0.5 / mol ** 0.5")
-    C_phi = C_phi * unit.Quantity("kg ** 2 /mol ** 2")
+    alpha1 = alpha1 * ureg.Quantity("kg ** 0.5 / mol ** 0.5")
+    alpha2 = alpha2 * ureg.Quantity("kg ** 0.5 / mol ** 0.5")
+    b = b * ureg.Quantity("kg ** 0.5 / mol ** 0.5")
+    C_phi = C_phi * ureg.Quantity("kg ** 2 /mol ** 2")
 
     # assign units appropriate for the activity parameters
-    BMX = _pitzer_B_MX(ionic_strength, alpha1, alpha2, beta0, beta1, beta2) * unit.Quantity("kg/mol")
-    Bphi = _pitzer_B_phi(ionic_strength, alpha1, alpha2, beta0, beta1, beta2) * unit.Quantity("kg/mol")
+    BMX = _pitzer_B_MX(ionic_strength, alpha1, alpha2, beta0, beta1, beta2) * ureg.Quantity("kg/mol")
+    Bphi = _pitzer_B_phi(ionic_strength, alpha1, alpha2, beta0, beta1, beta2) * ureg.Quantity("kg/mol")
 
     loggamma = _pitzer_log_gamma(
         ionic_strength,
@@ -505,7 +505,7 @@ def get_activity_coefficient_pitzer(
         b,
     )
 
-    return math.exp(loggamma) * unit.Quantity("1 dimensionless")
+    return math.exp(loggamma) * ureg.Quantity("1 dimensionless")
 
 
 def get_apparent_volume_pitzer(
@@ -566,22 +566,22 @@ def get_apparent_volume_pitzer(
 
     0.25 mol/kg CuSO4. Expected result (from graph) = 0.5 cm ** 3 / mol
 
-    >>> get_apparent_volume_pitzer(1.0*unit.Quantity('mol/kg'),0.25*unit.Quantity('mol/kg'),1.4,12,0.001499,-0.008124,0.2203,-0.0002589,-6,2,-2,1,1,b=1.2)
+    >>> get_apparent_volume_pitzer(1.0*ureg.Quantity('mol/kg'),0.25*ureg.Quantity('mol/kg'),1.4,12,0.001499,-0.008124,0.2203,-0.0002589,-6,2,-2,1,1,b=1.2)
     0.404...
 
     1.0 mol/kg CuSO4. Expected result (from graph) = 4 cm ** 3 / mol
 
-    >>> get_apparent_volume_pitzer(4.0*unit.Quantity('mol/kg'),1.0*unit.Quantity('mol/kg'),1.4,12,0.001499,-0.008124,0.2203,-0.0002589,-6,2,-2,1,1,b=1.2)
+    >>> get_apparent_volume_pitzer(4.0*ureg.Quantity('mol/kg'),1.0*ureg.Quantity('mol/kg'),1.4,12,0.001499,-0.008124,0.2203,-0.0002589,-6,2,-2,1,1,b=1.2)
     4.424...
 
     10.0 mol/kg ammonium nitrate. Expected result (from graph) = 50.3 cm ** 3 / mol
 
-    >>> get_apparent_volume_pitzer(10.0*unit.Quantity('mol/kg'),10.0*unit.Quantity('mol/kg'),2,0,0.000001742,0.0002926,0,0.000000424,46.9,1,-1,1,1,b=1.2)
+    >>> get_apparent_volume_pitzer(10.0*ureg.Quantity('mol/kg'),10.0*ureg.Quantity('mol/kg'),2,0,0.000001742,0.0002926,0,0.000000424,46.9,1,-1,1,1,b=1.2)
     50.286...
 
     20.0 mol/kg ammonium nitrate. Expected result (from graph) = 51.2 cm ** 3 / mol
 
-    >>> get_apparent_volume_pitzer(20.0*unit.Quantity('mol/kg'),20.0*unit.Quantity('mol/kg'),2,0,0.000001742,0.0002926,0,0.000000424,46.9,1,-1,1,1,b=1.2)
+    >>> get_apparent_volume_pitzer(20.0*ureg.Quantity('mol/kg'),20.0*ureg.Quantity('mol/kg'),2,0,0.000001742,0.0002926,0,0.000000424,46.9,1,-1,1,1,b=1.2)
     51.145...
 
     NOTE: the examples below are for comparison with experimental and modeling data presented in
@@ -589,7 +589,7 @@ def get_apparent_volume_pitzer(
 
     0.8 mol/kg NaF. Expected result = 0.03
 
-    >>> get_apparent_volume_pitzer(0.8*unit.Quantity('mol/kg'),0.8*unit.Quantity('mol/kg'),2,0,0.000024693,0.00003169,0,-0.000004068,-2.426,1,-1,1,1,b=1.2)
+    >>> get_apparent_volume_pitzer(0.8*ureg.Quantity('mol/kg'),0.8*ureg.Quantity('mol/kg'),2,0,0.000024693,0.00003169,0,-0.000004068,-2.426,1,-1,1,1,b=1.2)
     0.22595 ...
 
 
@@ -613,14 +613,14 @@ def get_apparent_volume_pitzer(
     """
     # TODO - find a cleaner way to make sure coefficients are assigned the proper units
     # if they aren't, the calculation gives very wrong results
-    alpha1 = alpha1 * unit.Quantity("kg ** 0.5 / mol ** 0.5")
-    alpha2 = alpha2 * unit.Quantity("kg ** 0.5 / mol ** 0.5")
-    b = b * unit.Quantity("kg ** 0.5 / mol ** 0.5")
-    C_phi = C_phi * unit.Quantity("kg ** 2 /mol ** 2 / dabar")
-    V_o = V_o * unit.Quantity("cm ** 3 / mol")
+    alpha1 = alpha1 * ureg.Quantity("kg ** 0.5 / mol ** 0.5")
+    alpha2 = alpha2 * ureg.Quantity("kg ** 0.5 / mol ** 0.5")
+    b = b * ureg.Quantity("kg ** 0.5 / mol ** 0.5")
+    C_phi = C_phi * ureg.Quantity("kg ** 2 /mol ** 2 / dabar")
+    V_o = V_o * ureg.Quantity("cm ** 3 / mol")
 
     # assign units appropriate for the volume parameter
-    BMX = _pitzer_B_MX(ionic_strength, alpha1, alpha2, beta0, beta1, beta2) * unit.Quantity("kg /mol/dabar")
+    BMX = _pitzer_B_MX(ionic_strength, alpha1, alpha2, beta0, beta1, beta2) * ureg.Quantity("kg /mol/dabar")
 
     second_term = (
         (nu_cation + nu_anion)
@@ -632,8 +632,8 @@ def get_apparent_volume_pitzer(
     third_term = (
         nu_cation
         * nu_anion
-        * unit.R
-        * unit.Quantity(temperature)
+        * ureg.R
+        * ureg.Quantity(temperature)
         * (2 * molality * BMX + molality**2 * C_phi * (nu_cation * nu_anion) ** 0.5)
     )
 
@@ -763,7 +763,7 @@ def _pitzer_B_MX(ionic_strength, alpha1, alpha2, beta0, beta1, beta2):
 #
 #    '''
 #    coeff = (beta1 * _pitzer_f2(alpha1 * ionic_strength ** 0.5) + beta2 * _pitzer_f2(alpha2 * ionic_strength ** 0.5)) / ionic_strength
-#    return coeff * unit.Quantity('kg/mol')
+#    return coeff * ureg.Quantity('kg/mol')
 
 
 def _pitzer_B_phi(ionic_strength, alpha1, alpha2, beta0, beta1, beta2):
@@ -838,7 +838,7 @@ def _pitzer_B_phi(ionic_strength, alpha1, alpha2, beta0, beta1, beta2):
 #    '''
 #
 #    coeff = C_phi / ( 2 * abs(z_cation * z_anion) ** 0.5 )
-#    return coeff * unit.Quantity('kg ** 2 /mol ** 2')
+#    return coeff * ureg.Quantity('kg ** 2 /mol ** 2')
 
 
 def _pitzer_log_gamma(
@@ -852,7 +852,7 @@ def _pitzer_log_gamma(
     nu_cation,
     nu_anion,
     temperature="25 degC",
-    b=unit.Quantity("1.2 kg**0.5/mol**0.5"),
+    b=ureg.Quantity("1.2 kg**0.5/mol**0.5"),
 ):
     """
     Return the natural logarithm of the binary activity coefficient calculated by the Pitzer
@@ -957,12 +957,12 @@ def get_osmotic_coefficient_pitzer(
     --------
     Experimental value according to Beyer and Stieger reference is 1.3550
 
-    >>> get_osmotic_coefficient_pitzer(10.175*unit.Quantity('mol/kg'),10.175*unit.Quantity('mol/kg'),1,0.5,-.0181191983,-.4625822071,.4682,.000246063,1,-1,1,1,b=1.2)
+    >>> get_osmotic_coefficient_pitzer(10.175*ureg.Quantity('mol/kg'),10.175*ureg.Quantity('mol/kg'),1,0.5,-.0181191983,-.4625822071,.4682,.000246063,1,-1,1,1,b=1.2)
     1.3552 ...
 
     Experimental value according to Beyer and Stieger reference is 1.084
 
-    >>> get_osmotic_coefficient_pitzer(5.6153*unit.Quantity('mol/kg'),5.6153*unit.Quantity('mol/kg'),3,0.5,0.0369993,0.354664,0.0997513,-0.00171868,1,-1,1,1,b=1.2)
+    >>> get_osmotic_coefficient_pitzer(5.6153*ureg.Quantity('mol/kg'),5.6153*ureg.Quantity('mol/kg'),3,0.5,0.0369993,0.354664,0.0997513,-0.00171868,1,-1,1,1,b=1.2)
     1.0850 ...
 
     NOTE: the examples below are for comparison with experimental and modeling data presented in
@@ -970,17 +970,17 @@ def get_osmotic_coefficient_pitzer(
 
     10 mol/kg ammonium nitrate. Estimated result (from graph) = 0.62
 
-    >>> get_osmotic_coefficient_pitzer(10*unit.Quantity('mol/kg'),10*unit.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
+    >>> get_osmotic_coefficient_pitzer(10*ureg.Quantity('mol/kg'),10*ureg.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
     0.6143 ...
 
     5 mol/kg ammonium nitrate. Estimated result (from graph) = 0.7
 
-    >>> get_osmotic_coefficient_pitzer(5*unit.Quantity('mol/kg'),5*unit.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
+    >>> get_osmotic_coefficient_pitzer(5*ureg.Quantity('mol/kg'),5*ureg.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
     0.6925 ...
 
     18 mol/kg ammonium nitrate. Estimated result (from graph) = 0.555
 
-    >>> get_osmotic_coefficient_pitzer(18*unit.Quantity('mol/kg'),18*unit.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
+    >>> get_osmotic_coefficient_pitzer(18*ureg.Quantity('mol/kg'),18*ureg.Quantity('mol/kg'),2,0,-0.01709,0.09198,0,0.000419,1,-1,1,1,b=1.2)
     0.5556 ...
 
     References
@@ -1011,11 +1011,11 @@ def get_osmotic_coefficient_pitzer(
 
     """
     # assign proper units to alpha1, alpha2, and b
-    alpha1 = alpha1 * unit.Quantity("kg ** 0.5 / mol ** 0.5")
-    alpha2 = alpha2 * unit.Quantity("kg ** 0.5 / mol ** 0.5")
-    b = b * unit.Quantity("kg ** 0.5 / mol ** 0.5")
-    C_phi = C_phi * unit.Quantity("kg ** 2 /mol ** 2")
-    B_phi = _pitzer_B_phi(ionic_strength, alpha1, alpha2, beta0, beta1, beta2) * unit.Quantity("kg/mol")
+    alpha1 = alpha1 * ureg.Quantity("kg ** 0.5 / mol ** 0.5")
+    alpha2 = alpha2 * ureg.Quantity("kg ** 0.5 / mol ** 0.5")
+    b = b * ureg.Quantity("kg ** 0.5 / mol ** 0.5")
+    C_phi = C_phi * ureg.Quantity("kg ** 2 /mol ** 2")
+    B_phi = _pitzer_B_phi(ionic_strength, alpha1, alpha2, beta0, beta1, beta2) * ureg.Quantity("kg/mol")
 
     first_term = 1 - _debye_parameter_osmotic(temperature) * abs(z_cation * z_anion) * ionic_strength**0.5 / (
         1 + b * ionic_strength**0.5

--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -14,7 +14,7 @@ import pyEQL.activity_correction as ac
 
 # import the parameters database
 # the pint unit registry
-from pyEQL import unit
+from pyEQL import ureg
 from pyEQL.logging_system import logger
 from pyEQL.salt_ion_match import generate_salt_list
 
@@ -99,18 +99,18 @@ class IdealEOS(EOS):
         Return the *molal scale* activity coefficient of solute, given a Solution
         object.
         """
-        return unit.Quantity("1 dimensionless")
+        return ureg.Quantity("1 dimensionless")
 
     def get_osmotic_coefficient(self, solution):
         """
         Return the *molal scale* osmotic coefficient of solute, given a Solution
         object.
         """
-        return unit.Quantity("1 dimensionless")
+        return ureg.Quantity("1 dimensionless")
 
     def get_solute_volume(self, solution):
         """Return the volume of the solutes."""
-        return unit.Quantity("0 L")
+        return ureg.Quantity("0 L")
 
     def equilibrate(self, solution):
         """Adjust the speciation of a Solution object to achieve chemical equilibrium."""
@@ -201,7 +201,7 @@ class NativeEOS(EOS):
         # show an error if no salt can be found that contains the solute
         if Salt is None:
             logger.warning("No salts found that contain solute %s. Returning unit activity coefficient." % solute)
-            return unit.Quantity("1 dimensionless")
+            return ureg.Quantity("1 dimensionless")
 
         # use the Pitzer model for higher ionic strength, if the parameters are available
 
@@ -241,10 +241,10 @@ class NativeEOS(EOS):
                 molality,
                 alpha1,
                 alpha2,
-                unit.Quantity(param["Beta0"]["value"]).magnitude,
-                unit.Quantity(param["Beta1"]["value"]).magnitude,
-                unit.Quantity(param["Beta2"]["value"]).magnitude,
-                unit.Quantity(param["Cphi"]["value"]).magnitude,
+                ureg.Quantity(param["Beta0"]["value"]).magnitude,
+                ureg.Quantity(param["Beta1"]["value"]).magnitude,
+                ureg.Quantity(param["Beta2"]["value"]).magnitude,
+                ureg.Quantity(param["Cphi"]["value"]).magnitude,
                 Salt.z_cation,
                 Salt.z_anion,
                 Salt.nu_cation,
@@ -299,7 +299,7 @@ class NativeEOS(EOS):
                 % solute
             )
 
-            molal = unit.Quantity("1 dimensionless")
+            molal = ureg.Quantity("1 dimensionless")
 
         return molal
 
@@ -425,10 +425,10 @@ class NativeEOS(EOS):
                     concentration,
                     alpha1,
                     alpha2,
-                    unit.Quantity(param["Beta0"]["value"]).magnitude,
-                    unit.Quantity(param["Beta1"]["value"]).magnitude,
-                    unit.Quantity(param["Beta2"]["value"]).magnitude,
-                    unit.Quantity(param["Cphi"]["value"]).magnitude,
+                    ureg.Quantity(param["Beta0"]["value"]).magnitude,
+                    ureg.Quantity(param["Beta1"]["value"]).magnitude,
+                    ureg.Quantity(param["Beta2"]["value"]).magnitude,
+                    ureg.Quantity(param["Cphi"]["value"]).magnitude,
                     item.z_cation,
                     item.z_anion,
                     item.nu_cation,
@@ -448,7 +448,7 @@ class NativeEOS(EOS):
                     "Cannot calculate osmotic coefficient because Pitzer parameters for salt %s are not specified. Returning unit osmotic coefficient"
                     % item.formula
                 )
-                effective_osmotic_sum += concentration * unit.Quantity("1 dimensionless")
+                effective_osmotic_sum += concentration * ureg.Quantity("1 dimensionless")
 
         return effective_osmotic_sum / molality_sum
 
@@ -464,7 +464,7 @@ class NativeEOS(EOS):
             if rform == salt.anion:
                 anion = i
 
-        solute_vol = unit.Quantity("0 L")
+        solute_vol = ureg.Quantity("0 L")
 
         # use the pitzer approach if parameters are available
 
@@ -497,11 +497,11 @@ class NativeEOS(EOS):
                 molality,
                 alpha1,
                 alpha2,
-                unit.Quantity(param["Beta0"]["value"]).magnitude,
-                unit.Quantity(param["Beta1"]["value"]).magnitude,
-                unit.Quantity(param["Beta2"]["value"]).magnitude,
-                unit.Quantity(param["Cphi"]["value"]).magnitude,
-                unit.Quantity(param["V_o"]["value"]).magnitude,
+                ureg.Quantity(param["Beta0"]["value"]).magnitude,
+                ureg.Quantity(param["Beta1"]["value"]).magnitude,
+                ureg.Quantity(param["Beta2"]["value"]).magnitude,
+                ureg.Quantity(param["Cphi"]["value"]).magnitude,
+                ureg.Quantity(param["V_o"]["value"]).magnitude,
                 salt.z_cation,
                 salt.z_anion,
                 salt.nu_cation,
@@ -535,7 +535,7 @@ class NativeEOS(EOS):
 
             part_vol = solution.get_property(solute, "size.molar_volume")
             if part_vol is not None:
-                solute_vol += part_vol * mol * unit.Quantity("1 mol")
+                solute_vol += part_vol * mol * ureg.Quantity("1 mol")
                 logger.info("Updated solution volume using direct partial molar volume for solute %s" % solute)
 
             else:

--- a/src/pyEQL/equilibrium.py
+++ b/src/pyEQL/equilibrium.py
@@ -12,11 +12,11 @@ NOTE: these methods are not currently used but are here for the future.
 import math
 
 # the pint unit registry
-from pyEQL import unit
+from pyEQL import ureg
 from pyEQL.logging_system import logger
 
 
-def adjust_temp_pitzer(c1, c2, c3, c4, c5, temp, temp_ref=unit.Quantity("298.15 K")):
+def adjust_temp_pitzer(c1, c2, c3, c4, c5, temp, temp_ref=ureg.Quantity("298.15 K")):
     """
     Calculate a parameter for the Pitzer model based on temperature-dependent
     coefficients c1,c2,c3,c4,and c5.
@@ -46,7 +46,7 @@ def adjust_temp_pitzer(c1, c2, c3, c4, c5, temp, temp_ref=unit.Quantity("298.15 
     )
 
 
-def adjust_temp_vanthoff(equilibrium_constant, enthalpy, temperature, reference_temperature=25 * unit.Quantity("degC")):
+def adjust_temp_vanthoff(equilibrium_constant, enthalpy, temperature, reference_temperature=25 * ureg.Quantity("degC")):
     r"""(float,float,number, optional number) -> float.
 
     Adjust a reaction equilibrium constant from one temperature to another.
@@ -86,17 +86,17 @@ def adjust_temp_vanthoff(equilibrium_constant, enthalpy, temperature, reference_
 
     Examples:
     --------
-    >>> adjust_temp_vanthoff(0.15,unit.Quantity('-197.6 kJ/mol'),unit.Quantity('42 degC'),unit.Quantity(' 25degC')) #doctest: +ELLIPSIS
+    >>> adjust_temp_vanthoff(0.15,ureg.Quantity('-197.6 kJ/mol'),ureg.Quantity('42 degC'),ureg.Quantity(' 25degC')) #doctest: +ELLIPSIS
     0.00203566...
 
     If the 'ref_temperature' parameter is omitted, a default of 25 C is used.
 
-    >>> adjust_temp_vanthoff(0.15,unit.Quantity('-197.6 kJ/mol'),unit.Quantity('42 degC')) #doctest: +ELLIPSIS
+    >>> adjust_temp_vanthoff(0.15,ureg.Quantity('-197.6 kJ/mol'),ureg.Quantity('42 degC')) #doctest: +ELLIPSIS
     0.00203566...
 
     """
     output = equilibrium_constant * math.exp(
-        enthalpy / unit.R * (1 / reference_temperature.to("K") - 1 / temperature.to("K"))
+        enthalpy / ureg.R * (1 / reference_temperature.to("K") - 1 / temperature.to("K"))
     )
 
     logger.info(
@@ -111,7 +111,7 @@ def adjust_temp_arrhenius(
     rate_constant,
     activation_energy,
     temperature,
-    reference_temperature=25 * unit.Quantity("degC"),
+    reference_temperature=25 * ureg.Quantity("degC"),
 ):
     r"""(float,float,number, optional number) -> float.
 
@@ -155,12 +155,12 @@ def adjust_temp_arrhenius(
 
     Examples:
     --------
-    >>> adjust_temp_arrhenius(7,900*unit.Quantity('kJ/mol'),37*unit.Quantity('degC'),97*unit.Quantity('degC')) #doctest: +ELLIPSIS
+    >>> adjust_temp_arrhenius(7,900*ureg.Quantity('kJ/mol'),37*ureg.Quantity('degC'),97*ureg.Quantity('degC')) #doctest: +ELLIPSIS
     1.8867225...e-24
 
     """
     output = rate_constant * math.exp(
-        activation_energy / unit.R * (1 / reference_temperature.to("K") - 1 / temperature.to("K"))
+        activation_energy / ureg.R * (1 / reference_temperature.to("K") - 1 / temperature.to("K"))
     )
 
     logger.info(

--- a/src/pyEQL/functions.py
+++ b/src/pyEQL/functions.py
@@ -8,7 +8,7 @@ pyEQL functions that take Solution objects as inputs or return Solution objects.
 import math
 
 import pyEQL
-from pyEQL import unit
+from pyEQL import ureg
 from pyEQL.logging_system import logger
 
 
@@ -60,7 +60,7 @@ def gibbs_mix(Solution1, Solution2):
             if solution.get_amount(solute, "fraction") != 0:
                 term_list[solution] += solution.get_amount(solute, "mol") * math.log(solution.get_activity(solute))
 
-    return (unit.R * blend.temperature.to("K") * (term_list[blend] - term_list[concentrate] - term_list[dilute])).to(
+    return (ureg.R * blend.temperature.to("K") * (term_list[blend] - term_list[concentrate] - term_list[dilute])).to(
         "J"
     )
 
@@ -115,7 +115,7 @@ def entropy_mix(Solution1, Solution2):
                     solution.get_amount(solute, "fraction")
                 )
 
-    return (unit.R * blend.temperature.to("K") * (term_list[blend] - term_list[concentrate] - term_list[dilute])).to(
+    return (ureg.R * blend.temperature.to("K") * (term_list[blend] - term_list[concentrate] - term_list[dilute])).to(
         "J"
     )
 
@@ -187,7 +187,7 @@ def donnan_eql(solution, fixed_charge):
     salt = solution.get_salt()
 
     # convert fixed_charge in to a quantity
-    fixed_charge = unit.Quantity(fixed_charge)
+    fixed_charge = ureg.Quantity(fixed_charge)
 
     # identify variables from the external solution
     conc_cation_soln = solution.get_amount(salt.cation, str(fixed_charge.units))
@@ -223,7 +223,7 @@ def donnan_eql(solution, fixed_charge):
 
     # the stuff in the term below doesn't change on iteration, so calculate it up-front
     # assign it the correct units and extract the magnitude for a performance gain
-    exp_term = (molar_volume / (unit.R * solution.temperature * z_cation * nu_cation)).to("1/Pa").magnitude
+    exp_term = (molar_volume / (ureg.R * solution.temperature * z_cation * nu_cation)).to("1/Pa").magnitude
 
     def donnan_solve(x):
         """Where x is the magnitude of co-ion concentration."""

--- a/tests/test_effective_pitzer.py
+++ b/tests/test_effective_pitzer.py
@@ -35,7 +35,7 @@ the paper, so perfect accuracy is not expected.
 import numpy as np
 import pyEQL
 import pytest
-from pyEQL import unit
+from pyEQL import ureg
 
 # relative tolerance between experimental and computed properties for this test file
 RTOL = 0.15
@@ -89,10 +89,10 @@ class Test_effective_pitzer:
                 molality,
                 alpha1,
                 alpha2,
-                unit.Quantity(param["Beta0"]["value"]).magnitude,
-                unit.Quantity(param["Beta1"]["value"]).magnitude,
-                unit.Quantity(param["Beta2"]["value"]).magnitude,
-                unit.Quantity(param["Cphi"]["value"]).magnitude,
+                ureg.Quantity(param["Beta0"]["value"]).magnitude,
+                ureg.Quantity(param["Beta1"]["value"]).magnitude,
+                ureg.Quantity(param["Beta2"]["value"]).magnitude,
+                ureg.Quantity(param["Cphi"]["value"]).magnitude,
                 Salt.z_cation,
                 Salt.z_anion,
                 Salt.nu_cation,
@@ -102,7 +102,7 @@ class Test_effective_pitzer:
 
             # convert the result to a rational activity coefficient
             result = activity_coefficient * (
-                1 + unit.Quantity("0.018015 kg/mol") * s1.get_total_moles_solute() / s1.solvent_mass
+                1 + ureg.Quantity("0.018015 kg/mol") * s1.get_total_moles_solute() / s1.solvent_mass
             )
 
             assert np.isclose(result, expected[item], RTOL)
@@ -127,10 +127,10 @@ class Test_effective_pitzer:
                 molality,
                 alpha1,
                 alpha2,
-                unit.Quantity(param["Beta0"]["value"]).magnitude,
-                unit.Quantity(param["Beta1"]["value"]).magnitude,
-                unit.Quantity(param["Beta2"]["value"]).magnitude,
-                unit.Quantity(param["Cphi"]["value"]).magnitude,
+                ureg.Quantity(param["Beta0"]["value"]).magnitude,
+                ureg.Quantity(param["Beta1"]["value"]).magnitude,
+                ureg.Quantity(param["Beta2"]["value"]).magnitude,
+                ureg.Quantity(param["Cphi"]["value"]).magnitude,
                 Salt.z_cation,
                 Salt.z_anion,
                 Salt.nu_cation,
@@ -140,7 +140,7 @@ class Test_effective_pitzer:
 
             # convert the result to a rational activity coefficient
             result = activity_coefficient * (
-                1 + unit.Quantity("0.018015 kg/mol") * s1.get_total_moles_solute() / s1.solvent_mass
+                1 + ureg.Quantity("0.018015 kg/mol") * s1.get_total_moles_solute() / s1.solvent_mass
             )
 
             assert np.isclose(result, expected[item], RTOL)
@@ -165,10 +165,10 @@ class Test_effective_pitzer:
                 molality,
                 alpha1,
                 alpha2,
-                unit.Quantity(param["Beta0"]["value"]).magnitude,
-                unit.Quantity(param["Beta1"]["value"]).magnitude,
-                unit.Quantity(param["Beta2"]["value"]).magnitude,
-                unit.Quantity(param["Cphi"]["value"]).magnitude,
+                ureg.Quantity(param["Beta0"]["value"]).magnitude,
+                ureg.Quantity(param["Beta1"]["value"]).magnitude,
+                ureg.Quantity(param["Beta2"]["value"]).magnitude,
+                ureg.Quantity(param["Cphi"]["value"]).magnitude,
                 Salt.z_cation,
                 Salt.z_anion,
                 Salt.nu_cation,
@@ -178,7 +178,7 @@ class Test_effective_pitzer:
 
             # convert the result to a rational activity coefficient
             result = activity_coefficient * (
-                1 + unit.Quantity("0.018015 kg/mol") * s1.get_total_moles_solute() / s1.solvent_mass
+                1 + ureg.Quantity("0.018015 kg/mol") * s1.get_total_moles_solute() / s1.solvent_mass
             )
 
             assert np.isclose(result, expected[item], RTOL)
@@ -204,10 +204,10 @@ class Test_effective_pitzer:
                 molality,
                 alpha1,
                 alpha2,
-                unit.Quantity(param["Beta0"]["value"]).magnitude,
-                unit.Quantity(param["Beta1"]["value"]).magnitude,
-                unit.Quantity(param["Beta2"]["value"]).magnitude,
-                unit.Quantity(param["Cphi"]["value"]).magnitude,
+                ureg.Quantity(param["Beta0"]["value"]).magnitude,
+                ureg.Quantity(param["Beta1"]["value"]).magnitude,
+                ureg.Quantity(param["Beta2"]["value"]).magnitude,
+                ureg.Quantity(param["Cphi"]["value"]).magnitude,
                 Salt.z_cation,
                 Salt.z_anion,
                 Salt.nu_cation,
@@ -217,7 +217,7 @@ class Test_effective_pitzer:
 
             # convert the result to a rational activity coefficient
             result = activity_coefficient * (
-                1 + unit.Quantity("0.018015 kg/mol") * s1.get_total_moles_solute() / s1.solvent_mass
+                1 + ureg.Quantity("0.018015 kg/mol") * s1.get_total_moles_solute() / s1.solvent_mass
             )
 
             assert np.isclose(result, expected[item], RTOL)

--- a/tests/test_solute_properties.py
+++ b/tests/test_solute_properties.py
@@ -14,7 +14,7 @@ in the testing are:
 """
 
 import numpy as np
-from pyEQL import Solution, unit
+from pyEQL import Solution, ureg
 
 # relative tolerance between experimental and computed properties for this test file
 RTOL = 0.05
@@ -65,7 +65,7 @@ class Test_molar_conductivity:
         # K+ - 73.48 x 10 ** -4 m ** 2 S / mol
         s1 = Solution([["K+", "0.001 mol/L"], ["Cl-", "0.001 mol/L"]], temperature="25 degC")
         result = s1.get_molar_conductivity("K+").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("73.48e-4 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("73.48e-4 m**2 * S / mol").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -73,7 +73,7 @@ class Test_molar_conductivity:
         # Na+ - 50.08 x 10 ** -4 m ** 2 S / mol
         s1 = Solution([["Na+", "0.001 mol/L"], ["Cl-", "0.001 mol/L"]], temperature="25 degC")
         result = s1.get_molar_conductivity("Na+").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("50.08e-4 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("50.08e-4 m**2 * S / mol").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -81,7 +81,7 @@ class Test_molar_conductivity:
         # Mg+2 - 106 x 10 ** -4 m ** 2 S / mol
         s1 = Solution([["Mg+2", "0.001 mol/L"], ["Cl-", "0.002 mol/L"]], temperature="25 degC")
         result = s1.get_molar_conductivity("Mg+2").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("106e-4 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("106e-4 m**2 * S / mol").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -89,7 +89,7 @@ class Test_molar_conductivity:
         # Cl- - 76.31 x 10 ** -4 m ** 2 S / mol
         s1 = Solution([["Na+", "0.001 mol/L"], ["Cl-", "0.001 mol/L"]], temperature="25 degC")
         result = s1.get_molar_conductivity("Cl-").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("76.31e-4 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("76.31e-4 m**2 * S / mol").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -97,7 +97,7 @@ class Test_molar_conductivity:
         # F- - 55.4 x 10 ** -4 m ** 2 S / mol
         s1 = Solution([["Na+", "0.001 mol/L"], ["F-", "0.001 mol/L"]], temperature="25 degC")
         result = s1.get_molar_conductivity("F-").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("55.4e-4 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("55.4e-4 m**2 * S / mol").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -105,7 +105,7 @@ class Test_molar_conductivity:
         # SO4-2 - 160 x 10 ** -4 m ** 2 S / mol
         s1 = Solution([["Na+", "0.002 mol/L"], ["SO4-2", "0.001 mol/L"]], temperature="25 degC")
         result = s1.get_molar_conductivity("SO4-2").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("160.0e-4 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("160.0e-4 m**2 * S / mol").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -113,7 +113,7 @@ class Test_molar_conductivity:
         # OH- - 198 x 10 ** -4 m ** 2 S / mol
         s1 = Solution(temperature="25 degC")
         result = s1.get_molar_conductivity("OH-").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("198e-4 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("198e-4 m**2 * S / mol").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -121,7 +121,7 @@ class Test_molar_conductivity:
         # H+ - 349.65 x 10 ** -4 m ** 2 S / mol
         s1 = Solution(temperature="25 degC")
         result = s1.get_molar_conductivity("H+").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("349.65e-4 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("349.65e-4 m**2 * S / mol").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -129,7 +129,7 @@ class Test_molar_conductivity:
     def test_molar_conductivity_neutral(self):
         s1 = Solution([["FeCl3", "0.001 mol/L"]], temperature="25 degC")
         result = s1.get_molar_conductivity("FeCl3").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("0 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("0 m**2 * S / mol").magnitude
 
         assert round(abs(result - expected), 5) == 0
 
@@ -137,7 +137,7 @@ class Test_molar_conductivity:
     def test_molar_conductivity_water(self):
         s1 = Solution(temperature="25 degC")
         result = s1.get_molar_conductivity("H2O").to("m**2*S/mol").magnitude
-        expected = unit.Quantity("0 m**2 * S / mol").magnitude
+        expected = ureg.Quantity("0 m**2 * S / mol").magnitude
 
         assert round(abs(result - expected), 5) == 0
 
@@ -162,7 +162,7 @@ class Test_mobility:
         expected = s1.get_mobility("K+").to("m**2/s/V").magnitude
         charge = s1.get_property("K+", "charge")
         # calculate the mobility from get_molar_conductivity, then compare with get_mobility
-        result = (molar_conductivity / (unit.N_A * unit.e * abs(charge))).to("m**2/s/V").magnitude
+        result = (molar_conductivity / (ureg.N_A * ureg.e * abs(charge))).to("m**2/s/V").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -172,7 +172,7 @@ class Test_mobility:
         expected = s1.get_mobility("Cl-").to("m**2/s/V").magnitude
         charge = s1.get_property("Cl-", "charge")
         # calculate the mobility from get_molar_conductivity, then compare with get_mobility
-        result = (molar_conductivity / (unit.N_A * unit.e * abs(charge))).to("m**2/s/V").magnitude
+        result = (molar_conductivity / (ureg.N_A * ureg.e * abs(charge))).to("m**2/s/V").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -182,7 +182,7 @@ class Test_mobility:
         expected = s1.get_mobility("Mg+2").to("m**2/s/V").magnitude
         charge = s1.get_property("Mg+2", "charge")
         # calculate the mobility from get_molar_conductivity, then compare with get_mobility
-        result = (molar_conductivity / (unit.N_A * unit.e * abs(charge))).to("m**2/s/V").magnitude
+        result = (molar_conductivity / (ureg.N_A * ureg.e * abs(charge))).to("m**2/s/V").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)
 
@@ -192,6 +192,6 @@ class Test_mobility:
         expected = s1.get_mobility("SO4-2").to("m**2/s/V").magnitude
         charge = s1.get_property("SO4-2", "charge")
         # calculate the mobility from get_molar_conductivity, then compare with get_mobility
-        result = (molar_conductivity / (unit.N_A * unit.e * abs(charge))).to("m**2/s/V").magnitude
+        result = (molar_conductivity / (ureg.N_A * ureg.e * abs(charge))).to("m**2/s/V").magnitude
 
         assert np.isclose(result, expected, rtol=RTOL)

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -8,7 +8,7 @@ used by pyEQL's Solution class
 
 import numpy as np
 import pytest
-from pyEQL import Solution, unit
+from pyEQL import Solution, ureg
 
 
 @pytest.fixture()
@@ -145,11 +145,11 @@ def test_alkalinity_hardness_chargebalance(s3, s5, s6):
 def test_pressure_temperature(s5):
     orig_V = s5.volume
     s5.temperature = "50 degC"
-    assert s5.temperature == unit.Quantity("50 degC")
+    assert s5.temperature == ureg.Quantity("50 degC")
     assert s5.volume > orig_V
     intermediate_V = s5.volume
     s5.pressure = "2 atm"
-    assert s5.pressure == unit.Quantity("2 atm")
+    assert s5.pressure == ureg.Quantity("2 atm")
     assert s5.volume < intermediate_V
 
 
@@ -195,7 +195,7 @@ def test_get_amount(s3, s5):
     # TODO - make this test more precise i.e. test numerical values
     for u in TEST_UNITS:
         qty = s3.get_amount("Na+", u)
-        assert isinstance(qty, unit.Quantity), f"get_amount() failed for unit {u}"
+        assert isinstance(qty, ureg.Quantity), f"get_amount() failed for unit {u}"
         assert qty.magnitude > 0
     assert s3.get_amount("Na+", "ppm") == s3.get_amount("Na+", "mg/L")
     assert s3.get_amount("Na+", "ppb") == s3.get_amount("Na+", "ug/L")


### PR DESCRIPTION
## Summary

rename pyEQL's internal registry from `unit` to `ureg`. This accomplishes two things:

1. Reduce the likelihood of name collisions when `unit` or `units` is used as a kwarg in a function call
2. Make use of `Quantity` within pyEQL entirely consistent with the `pint` documentation, which almost always assigns the unit registry to the variable `ureg`.