### PR TITLE
Solution: sanitize all formulas

### DIFF
--- a/src/pyEQL/salt_ion_match.py
+++ b/src/pyEQL/salt_ion_match.py
@@ -166,12 +166,12 @@ def identify_salt(sol):
     anion = "OH-"
 
     # return water if there are no solutes
-    if len(sort_list) < 3 and sort_list[0] == "H2O":
+    if len(sort_list) < 3 and sort_list[0] == "H2O(aq)":
         logger.info("Salt matching aborted because there are not enough solutes.")
         return Salt(cation, anion)
 
     # warn if something other than water is the predominant component
-    if sort_list[0] != "H2O":
+    if sort_list[0] != "H2O(aq)":
         logger.warning("H2O is not the most prominent component")
 
     # take the dominant cation and anion and assemble a salt from them

--- a/src/pyEQL/utils.py
+++ b/src/pyEQL/utils.py
@@ -1,0 +1,29 @@
+"""
+pyEQL utilities
+
+:copyright: 2023 by Ryan S. Kingsbury
+:license: LGPL, see LICENSE for more details.
+
+"""
+
+from collections import UserDict
+
+from pymatgen.core.ion import Ion
+
+
+class FormulaDict(UserDict):
+    """
+    Automatically converts keys on get/set using pymatgen.core.Ion.from_formula(key).reduced_formula.
+
+    This allows getting/setting/updating of Solution.components using flexible
+    formula notation (e.g., "Na+", "Na+1", "Na[+]" all have the same effect)
+    """
+
+    def __getitem__(self, key):
+        return super().__getitem__(Ion.from_formula(key).reduced_formula)
+
+    def __setitem__(self, key, value):
+        super().__setitem__(Ion.from_formula(key).reduced_formula, value)
+
+    def __delitem__(self, key):
+        super().__delitem__(Ion.from_formula(key).reduced_formula)

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -64,7 +64,7 @@ def test_empty_solution_3():
     # It should have exactly 1L volume
     assert s1.volume.to("L").magnitude == 1.0
     #  the solvent should be water
-    assert s1.solvent == "H2O"
+    assert s1.solvent == "H2O(aq)"
     # It should have 0.997 kg water mass
     assert np.isclose(s1.solvent_mass.to("kg").magnitude, 0.9970415)
     # the temperature should be 25 degC
@@ -76,7 +76,7 @@ def test_empty_solution_3():
     assert np.isclose(s1.pH, 7.0, atol=0.01)
     assert np.isclose(s1.pE, 8.5)
     # it should contain H2O, H+, and OH- species
-    assert set(s1.list_solutes()) == {"H2O", "OH-", "H+"}
+    assert set(s1.list_solutes()) == {"H2O(aq)", "OH[-1]", "H[+1]"}
 
 
 def test_init_raises():
@@ -250,11 +250,10 @@ def test_arithmetic_and_copy(s2, s6):
     initial_mix_vol = s2.volume.to("L").magnitude + s6.volume.to("L").magnitude
     mix = s2 + s6
     assert isinstance(mix, Solution)
-    # TODO - currently solute names are not sanitized in Solution.components, leading to the following issue when
-    # solutions are mixed and the same solute has been specified differently in each
-    # assert mix.get_amount("Na+", "mol").magnitude == 8.01 # 4 M x 2 L + 10 mM x 1 L # <- will fail
-    assert mix.get_amount("Na+", "mol").magnitude == 8.0
-    assert mix.get_amount("Na+1", "mol").magnitude == 0.01
+
+    assert mix.get_amount("Na+", "mol").magnitude == 8.01  # 4 M x 2 L + 10 mM x 1 L
+    assert mix.get_amount("Na+", "mol").magnitude == 8.01
+    assert mix.get_amount("Na+1", "mol").magnitude == 8.01
     assert mix.get_amount("Cl-", "mol").magnitude == 8.0
     assert mix.get_amount("Br-", "mol").magnitude == 0.02
     assert np.isclose(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+"""
+Tests of pyEQL.utils module
+
+"""
+
+from pyEQL.utils import FormulaDict
+
+
+def test_formula_dict():
+    """
+    Make sure flexible key getting/setting works
+    """
+    d = FormulaDict({"Na+": 0.5, "Cl-1": 1.5, "Mg++": 0.5})
+    # assert d == {"Na[+1]": 0.5, "Cl[-1]": 1.5, "Mg[+2]": 0.5}
+    # sanitizing of keys should happen automagically
+    # assert "Na+" in d
+    del d["Mg+2"]
+    assert "Mg[+2]" not in d
+    assert not d.get("Mg[++]")
+    d.update({"Cl-": 0.5})
+    print(d, d.data)
+    assert d["Cl[-1]"] == 0.5
+    assert d.get("Na+") == 0.5
+    d.update({"Br-": 2})
+    assert d["Br[-]"] == 2


### PR DESCRIPTION
Although `Solution` uses `pymatgen.core.ion.Ion.reduced_formula` to uniquely identify solutes in the database, sanitizing user-supplied formulas was not always reliable.

This PR implements robust sanitizing for user entries formulas by changing `Solution.components` from a regular `dict` into an overloaded classes called `FormulaDict`. `FormulaDict` behaves exactly like a normal dict, except that formulas (keys) are automatically passed through `pymatgen.core.ion.Ion.reduced_formula` during get/set/delete operations. This way, `Solution` will always have unique keys for a solute and the user can enter inconsistent solute identifiers (e.g. Na+ vs. Na+1).