### PR TITLE
Solution: enable passing EOS instance as engine

### DIFF
--- a/src/pyEQL/engines.py
+++ b/src/pyEQL/engines.py
@@ -391,7 +391,7 @@ class NativeEOS(EOS):
         # coefficient
         for item in salts_dict:
             # ignore HOH in the salt list
-            if item == "HOH":
+            if item.formula == "HOH":
                 continue
 
             # determine alpha1 and alpha2 based on the type of salt

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -45,7 +45,7 @@ class Solution(MSONable):
         pH: float = 7,
         pE: float = 8.5,
         solvent: str | list = "H2O",
-        engine: Literal["native", "ideal"] = "native",
+        engine: EOS | Literal["native", "ideal"] = "native",
         database: str | Path | Store | None = None,
     ):
         """
@@ -147,8 +147,10 @@ class Solution(MSONable):
         # set the equation of state engine
         self._engine = engine
         # self.engine: Optional[EOS] = None
-        if self._engine == "ideal":
-            self.engine: EOS = IdealEOS()
+        if isinstance(self._engine, EOS):
+            self.engine: EOS = self._engine
+        elif self._engine == "ideal":
+            self.engine = IdealEOS()
         elif self._engine == "native":
             self.engine = NativeEOS()
         else:

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -9,6 +9,7 @@ used by pyEQL's Solution class
 import numpy as np
 import pytest
 from pyEQL import Solution, ureg
+from pyEQL.engines import IdealEOS, NativeEOS
 
 
 @pytest.fixture()
@@ -86,6 +87,23 @@ def test_init_raises():
         Solution(solvent="D2O")
     with pytest.raises(ValueError, match="Multiple solvents"):
         Solution(solvent=["D2O", "MeOH"])
+
+
+def test_init_engines():
+    """
+    Test passing an EOS instance as well as the ideal and native EOS
+    """
+    ideal = IdealEOS()
+    s = Solution([["Na+", "4 mol/L"], ["Cl-", "4 mol/L"]], engine=ideal)
+    assert s.engine == ideal
+    s = Solution([["Na+", "4 mol/L"], ["Cl-", "4 mol/L"]], engine="ideal")
+    assert isinstance(s.engine, IdealEOS)
+    assert s.get_activity_coefficient("Na+").magnitude == 1
+    assert s.get_osmotic_coefficient().magnitude == 1
+    s = Solution([["Na+", "4 mol/L"], ["Cl-", "4 mol/L"]], engine="native")
+    assert isinstance(s.engine, NativeEOS)
+    assert s.get_activity_coefficient("Na+").magnitude < 1
+    assert s.get_osmotic_coefficient().magnitude != 1
 
 
 # create an empty and test solutions with the same volume using substance / volume,


### PR DESCRIPTION
## Summary

This PR adds the ability to pass an `EOS` instance as an `engine` kwarg to `Solution`, rather than just strings. This opens the possibility to pass customized `EOS` classes that have not been hard-coded into `Solution.__init__`.

It also fixes a small bug in which the `NativeEOS` was not properly ignoring `HOH` as the salt in very dilute solutions.