### PR TITLE
add PhreeqcEOS electrolyte modeling engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2023-09-27
 
 ### Added
 
+- New electrolyte engine `PhreeqcEOS` provides `phreeqpython` activities within `pyEQL`
 - `Solution`: use total element concentrations when performing salt matching (can be disabled via kwarg)
 - `Solution`: add speciation support to the native engine via `phreeqpython`
 - `Solution`: add keyword argument to enable automatic charge balancing
@@ -22,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `pH` attribute is now calculated from the H+ concentration rather than its activity. For the old behavior,
+  use `Solution.p('H+')` which defaults to applying the activity correction.
 - Update `test_salt_ion_match` to `pytest` format and add additional tests
 - Update `test_bulk_properties` to `pytest` format
 

--- a/src/pyEQL/equilibrium.py
+++ b/src/pyEQL/equilibrium.py
@@ -20,6 +20,7 @@ from phreeqpython import PhreeqPython
 from pyEQL import ureg
 from pyEQL.logging_system import logger
 
+# TODO - not used. Remove?
 SPECIES_ALIAISES = {
     "Sodium": "Na+",
     "Potassium": "K+",
@@ -56,13 +57,7 @@ def equilibrate_phreeqc(
                 similar to vitens.dat but has many more species. `pitzer.dat` is recommended
                 when accurate activity coefficients in solutions above 1 M TDS are desired, but
                 it has fewer species than the other databases. `llnl.dat` and `geothermal.dat`
-                may offer improved prediction of LSI but currently these databases are not
-                usable because they do not allow for conductivity calculations.
-
-    1. create an empty PHREEQC solution with correct pH, pE, etc.
-    2. add each component using a REACTION block
-
-
+                may offer improved prediction of LSI.
     """
     solv_mass = solution.solvent_mass.to("kg").magnitude
     # inherit bulk solution properties

--- a/src/pyEQL/solution.py
+++ b/src/pyEQL/solution.py
@@ -2081,7 +2081,7 @@ class Solution(MSONable):
                         / base_temperature
                         * self.water_substance.mu
                         * ureg.Quantity("1 Pa*s")
-                        / self.get_viscosity_dynamic()
+                        / self.viscosity_dynamic
                     ).to("m**2/s")
                 return data
 

--- a/tests/test_phreeqc.py
+++ b/tests/test_phreeqc.py
@@ -1,0 +1,183 @@
+"""
+pyEQL volume and concentration methods test suite
+=================================================
+
+This file contains tests for the volume and concentration-related methods
+used by pyEQL's Solution class
+"""
+
+import numpy as np
+import pytest
+
+from pyEQL import Solution
+from pyEQL.engines import PhreeqcEOS
+
+
+@pytest.fixture()
+def s1():
+    return Solution(volume="2 L", engine="phreeqc")
+
+
+@pytest.fixture()
+def s2():
+    return Solution([["Na+", "4 mol/L"], ["Cl-", "4 mol/L"]], volume="2 L", engine="phreeqc")
+
+
+@pytest.fixture()
+def s3():
+    return Solution([["Na+", "4 mol/kg"], ["Cl-", "4 mol/kg"]], volume="2 L", engine="phreeqc")
+
+
+@pytest.fixture()
+def s5():
+    # 100 mg/L as CaCO3 ~ 1 mM
+    return Solution([["Ca+2", "40.078 mg/L"], ["CO3-2", "60.0089 mg/L"]], volume="1 L", engine="phreeqc")
+
+
+@pytest.fixture()
+def s5_pH():
+    # 100 mg/L as CaCO3 ~ 1 mM
+    return Solution([["Ca+2", "40.078 mg/L"], ["CO3-2", "60.0089 mg/L"]], volume="1 L", balance_charge="pH")
+
+
+@pytest.fixture()
+def s6():
+    # non-electroneutral solution with lots of hardness
+    # alk = -118 meq/L * 50 = -5900 mg/L, hardness = 12*50 = 600 mg/L as CaCO3
+    # charge balance = 2+10+10+10-120-20-12 = -120 meq/L
+    return Solution(
+        [
+            ["Ca+2", "1 mM"],  # 2 meq/L
+            ["Mg+2", "5 mM"],  # 10 meq/L
+            ["Na+1", "10 mM"],  # 10 meq/L
+            ["Ag+1", "10 mM"],  # no contribution to alk or hardness
+            ["CO3-2", "6 mM"],  # no contribution to alk or hardness
+            ["SO4-2", "60 mM"],  # -120 meq/L
+            ["Br-", "20 mM"],
+        ],  # -20 meq/L
+        volume="1 L",
+    )
+
+
+@pytest.fixture()
+def s6_Ca():
+    # non-electroneutral solution with lots of hardness
+    # alk = -118 meq/L * 50 = -5900 mg/L, hardness = 12*50 = 600 mg/L as CaCO3
+    # charge balance = 2+10+10+10-120-20-12 = -120 meq/L
+    return Solution(
+        [
+            ["Ca+2", "1 mM"],  # 2 meq/L
+            ["Mg+2", "5 mM"],  # 10 meq/L
+            ["Na+1", "10 mM"],  # 10 meq/L
+            ["Ag+1", "10 mM"],  # no contribution to alk or hardness
+            ["CO3-2", "6 mM"],  # no contribution to alk or hardness
+            ["SO4-2", "60 mM"],  # -120 meq/L
+            ["Br-", "20 mM"],
+        ],  # -20 meq/L
+        volume="1 L",
+        balance_charge="Ca+2",
+    )
+
+
+def test_empty_solution_3():
+    # create an empty solution
+    s1 = Solution(database=None, engine="phreeqc")
+    # It should return type Solution
+    assert isinstance(s1, Solution)
+    # It should have exactly 1L volume
+    assert s1.volume.to("L").magnitude == 1.0
+    #  the solvent should be water
+    assert s1.solvent == "H2O(aq)"
+    # It should have 0.997 kg water mass
+    assert np.isclose(s1.solvent_mass.to("kg").magnitude, 0.997, atol=1e-3)
+    # the temperature should be 25 degC
+    assert s1.temperature.to("degC").magnitude == 25
+    # the pressure should be 1 atm
+    assert s1.pressure.to("atm").magnitude == 1
+    # the pH should be 7.0
+    assert np.isclose(s1.get_activity("H+"), 1e-7, atol=1e-9)
+    # assert np.isclose(s1.pH, 7.0, atol=0.01)
+    assert np.isclose(s1.pE, 8.5)
+    # it should contain H2O, H+, and OH- species
+    assert set(s1.list_solutes()) == {"H2O(aq)", "OH[-1]", "H[+1]"}
+
+
+def test_init_engines():
+    """
+    Test passing an EOS instance as well as the ideal and native EOS
+    """
+    s = Solution([["Na+", "4 mol/L"], ["Cl-", "4 mol/L"]], engine="phreeqc")
+    assert isinstance(s.engine, PhreeqcEOS)
+    assert s.get_activity_coefficient("Na+").magnitude * s.get_activity_coefficient("Cl-").magnitude < 1
+    assert s.get_osmotic_coefficient().magnitude == 1
+
+
+def test_conductivity(s1, s2):
+    # even an empty solution should have some conductivity
+    assert s1.conductivity > 0
+    # per CRC handbook "standard Kcl solutions for calibratinG conductiVity cells", 0.1m KCl has a conductivity of 12.824 mS/cm at 25 C
+    s_kcl = Solution({"K+": "0.1 mol/kg", "Cl-": "0.1 mol/kg"})
+    assert np.isclose(s_kcl.conductivity.magnitude, 1.2824, atol=0.02)  # conductivity is in S/m
+
+    # TODO - expected failures due to limited temp adjustment of diffusion coeff
+    # s_kcl.temperature = '5 degC'
+    # assert np.isclose(s_kcl.conductivity.magnitude, 0.81837, atol=0.02)
+
+    # s_kcl.temperature = '50 degC'
+    # assert np.isclose(s_kcl.conductivity.magnitude, 1.91809, atol=0.02)
+
+    # TODO - conductivity model not very accurate at high conc.
+    s_kcl = Solution({"K+": "1 mol/kg", "Cl-": "1 mol/kg"})
+    assert np.isclose(s_kcl.conductivity.magnitude, 10.862, rtol=0.2)
+
+
+def test_equilibrate(s1, s2, s5_pH):
+    assert "H2(aq)" not in s1.components
+    orig_pH = s1.pH
+    orig_pE = s1.pE
+    s1.equilibrate()
+    assert "H2(aq)" in s1.components
+    assert np.isclose(s1.charge_balance, 0, atol=1e-7)
+    assert np.isclose(s1.pH, orig_pH, atol=0.01)
+    assert np.isclose(s1.pE, orig_pE)
+
+    assert "NaOH(aq)" not in s2.components
+    s2.equilibrate()
+    orig_pH = s2.pH
+    orig_pE = s2.pE
+    orig_density = s2.density.magnitude
+    orig_solv_mass = s2.solvent_mass.magnitude
+    assert "NaOH(aq)" in s2.components
+
+    # total element concentrations should be conserved after equilibrating
+    assert np.isclose(s2.get_total_amount("Na", "mol").magnitude, 8)
+    assert np.isclose(s2.get_total_amount("Cl", "mol").magnitude, 8)
+    assert np.isclose(s2.solvent_mass.magnitude, orig_solv_mass)
+    assert np.isclose(s2.density.magnitude, orig_density)
+    assert np.isclose(s2.charge_balance, 0, atol=1e-7)
+    assert np.isclose(s2.pH, orig_pH, atol=0.01)
+    assert np.isclose(s2.pE, orig_pE)
+
+    # this solution is the only one in the test that contains alkalinity
+    # and equilibrating it results in a shift in the pH
+    # the CO3-2 initially present reacts with the water to consume H+ and
+    # increase the pH by approximately 0.0006 M (b/c at pH 7 virtually all
+    # carbonate is present as HCO3-) -log10(0.001) =
+    assert "HCO3[-1]" not in s5_pH.components
+    assert np.isclose(s5_pH.charge_balance, 0)
+    orig_pH = s5_pH.pH
+    orig_pE = s5_pH.pE
+    orig_density = s5_pH.density.magnitude
+    orig_solv_mass = s5_pH.solvent_mass.magnitude
+    set(s5_pH.components.keys())
+    s5_pH.equilibrate()
+    assert np.isclose(s5_pH.get_total_amount("Ca", "mol").magnitude, 0.001)
+    assert np.isclose(s5_pH.get_total_amount("C(4)", "mol").magnitude, 0.001)
+    # due to the large pH shift, water mass and density need not be perfectly conserved
+    assert np.isclose(s5_pH.solvent_mass.magnitude, orig_solv_mass, atol=1e-3)
+    assert np.isclose(s5_pH.density.magnitude, orig_density, atol=1e-3)
+    assert np.isclose(s5_pH.charge_balance, 0)
+    assert "CaOH[+1]" in s5_pH.components
+    assert "HCO3[-1]" in s5_pH.components
+    assert s5_pH.pH > orig_pH
+    assert np.isclose(s5_pH.pE, orig_pE)

--- a/tests/test_volume_concentration.py
+++ b/tests/test_volume_concentration.py
@@ -7,8 +7,9 @@ used by pyEQL's Solution class
 """
 
 import numpy as np
-import pyEQL
 import pytest
+
+import pyEQL
 
 
 @pytest.fixture()
@@ -149,10 +150,14 @@ class Test_solute_addition:
         # If the concentration of a solute is directly increased with a substance / mass
         # unit, the water mass should not change
         original = s3.solvent_mass.to("kg").magnitude
+        V_orig = s3.volume.to("L").magnitude
         s3.add_amount("Na+", "1 mol/kg")
         s3.add_amount("Cl-", "1 mol/kg")
         assert np.allclose(s3.solvent_mass.to("kg").magnitude, original)
-        assert np.isclose(s3.pH, 7.0, atol=0.01)
+        assert s3.volume.to("L").magnitude > V_orig
+        # pH will be slightly higher than 7 b/c the addition of solute caused the
+        # solution volume to increase, so lower mol/L = higher pH
+        assert np.isclose(s3.pH, 7.0, atol=0.05)
         assert np.isclose(s3.pE, 8.5)
 
     def test_add_amount_12(self, s3):


### PR DESCRIPTION
Adds an `engine` class that directly uses `phreeqpython` to compute activity coefficients in addition to speciation (which is used in the `NativeEOS` as well).

This engine currently returns a unit osmotic coefficient and 0 partial molar volume for all solutes, which _appears_ to be consistent with the way `phreeqpython` behaves (at least using the non-pitzer databases), but more work may be required on this in the future.

**Subtle but important change** - the `pH` attribute of `Solution` is now calculated based only on the H+ concentration, not its activity.